### PR TITLE
fix: ensure full name searches return results

### DIFF
--- a/ContactSystem.API/Controllers/ContactsController.cs
+++ b/ContactSystem.API/Controllers/ContactsController.cs
@@ -23,7 +23,7 @@ public class ContactsController : ControllerBase
     /// <summary>
     /// Retrieves a list of Contacts based on the provided search criteria.
     /// </summary>
-    /// <param name="name">The name to search for Contacts.</param>
+    /// <param name="searchTerm">The name or email to search for Contacts.</param>
     /// <param name="officeId">The GUID of the office to search. If omitted, searches all offices.</param>
     /// <param name="page">The page number for pagination.</param>
     /// <param name="pageSize">The number of records per page.</param>
@@ -37,14 +37,14 @@ public class ContactsController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<object>), 500)]
     [Produces("application/json")]
     [MapToApiVersion("1.0")]
-    public async Task<ActionResult<ApiResponse<IEnumerable<ContactDto>>>> GetContacts([FromQuery] string name, [FromQuery] Guid? officeId = null, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    public async Task<ActionResult<ApiResponse<IEnumerable<ContactDto>>>> GetContacts([FromQuery] string searchTerm, [FromQuery] Guid? officeId = null, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
-        if (string.IsNullOrWhiteSpace(name))
+        if (string.IsNullOrWhiteSpace(searchTerm))
         {
             return BadRequest(new ApiResponse<IEnumerable<ContactDto>?>(false, "Search term cannot be empty", null));
         }
 
-        var contactDtos = (await _contactsService.SearchContactsAsync(name, officeId, page, pageSize)).ToList();
+        var contactDtos = (await _contactsService.SearchContactsAsync(searchTerm, officeId, page, pageSize)).ToList();
 
         return new ApiResponse<IEnumerable<ContactDto>>(true, "Contacts retrieved successfully",  contactDtos, contactDtos.Count);
     }

--- a/ContactSystem.Application/Repositories/Interfaces/IContactsRepository.cs
+++ b/ContactSystem.Application/Repositories/Interfaces/IContactsRepository.cs
@@ -4,5 +4,5 @@ namespace ContactSystem.Application.Repositories.Interfaces;
 
 public interface IContactsRepository : IEntitiesRepository<ContactEntity, Guid>
 {
-    Task<IEnumerable<ContactEntity>> GetContactsByNameAsync(string searchTerm, Guid? officeId, int page, int pageSize);
+    Task<IEnumerable<ContactEntity>> GetContactsByNameOrEmailAsync(string searchTerm, Guid? officeId, int page, int pageSize);
 }

--- a/ContactSystem.Application/Services/ContactsService.cs
+++ b/ContactSystem.Application/Services/ContactsService.cs
@@ -41,7 +41,7 @@ public class ContactsService : IContactsService
 
     public async Task<IEnumerable<ContactDto>> SearchContactsAsync(string searchTerm, Guid? officeId, int page, int pageSize)
     {
-        var contactEntities = await _contactsRepository.GetContactsByNameAsync(searchTerm, officeId, page, pageSize);
+        var contactEntities = await _contactsRepository.GetContactsByNameOrEmailAsync(searchTerm, officeId, page, pageSize);
         
         var contactDtos = contactEntities.Select(c =>
         {

--- a/ContactSystem.Infrastructure/Repositories/ContactsRepository.cs
+++ b/ContactSystem.Infrastructure/Repositories/ContactsRepository.cs
@@ -10,14 +10,13 @@ public class ContactsRepository : EntityRepository<ContactEntity, Guid>, IContac
     {
     }
 
-    public async Task<IEnumerable<ContactEntity>> GetContactsByNameAsync(string searchTerm, Guid? officeId, int page, int pageSize)
+    public async Task<IEnumerable<ContactEntity>> GetContactsByNameOrEmailAsync(string searchTerm, Guid? officeId, int page, int pageSize)
     {
         var query = _dbSet.Include(p => p.ContactOffices)!
             .ThenInclude(cor => cor.Office)
             .Where(p =>
-                p.FirstName.Contains(searchTerm, StringComparison.CurrentCultureIgnoreCase) ||
-                p.LastName.Contains(searchTerm, StringComparison.CurrentCultureIgnoreCase) ||
-                p.Email.Contains(searchTerm, StringComparison.CurrentCultureIgnoreCase));
+                ((p.FirstName ?? "") + " " + (p.LastName ?? "")).ToLower().Contains(searchTerm.ToLower()) ||
+                p.Email.ToLower().Contains(searchTerm.ToLower()));
 
         if (officeId.HasValue)
         {

--- a/contacts-ui/src/ContactsSearchPage.jsx
+++ b/contacts-ui/src/ContactsSearchPage.jsx
@@ -22,7 +22,7 @@ export default function ContactSearch() {
 
   const fetchContacts = (pageNumber) => {
     const params = new URLSearchParams({
-      name: searchTerm,
+      searchTerm: searchTerm,
       page: pageNumber.toString(),
       pageSize: pageSize.toString(),
     });


### PR DESCRIPTION
- Make repository search EF-friendly, regardless of data provider
- Search full name (first + last) as single unit instead of separately
- BREAKING CHANGE: Rename query parameter "name" to "searchTerm"